### PR TITLE
Fix/empy labels

### DIFF
--- a/src/GatherContent/ConfigValueObject/Validator.php
+++ b/src/GatherContent/ConfigValueObject/Validator.php
@@ -4,6 +4,21 @@ namespace GatherContent\ConfigValueObject;
 
 final class Validator
 {
+    public static function notBlank($value, $message = null, string $propertyPath = null): bool
+    {
+        if (false === $value || (empty($value) && '0' != $value) ) {
+
+            $message = sprintf(
+                $message ?: 'Value "%s" is blank, but was expected to contain a value.',
+                (string) $value
+            );
+
+            throw new \Assert\InvalidArgumentException($value, $message, Assertion::INVALID_NOT_BLANK, $propertyPath);
+        }
+
+        return true;
+    }
+
     public function validate($config)
     {
         $this->validateConfigNotEmpty($config);
@@ -17,7 +32,7 @@ final class Validator
     private function validateConfigNotEmpty($config)
     {
         Assertion::isArray($config, 'Config must be array');
-        Assertion::notEmpty($config, 'Config must not be empty');
+        $this->notBlank($config, 'Config must not be empty');
     }
 
     private function validateTabFormat($config)
@@ -34,8 +49,8 @@ final class Validator
             Assertion::string($tab->name, 'Tab name attribute must be string');
             Assertion::boolean($tab->hidden, 'Tab hidden attribute must be boolean');
             Assertion::isArray($tab->elements, 'Tab elements attribute must be array');
-            Assertion::notBlank($tab->label, 'Tab label attribute must not be empty');
-            Assertion::notBlank($tab->name, 'Tab name attribute must not be empty');
+            $this->notBlank($tab->label, 'Tab label attribute must not be empty');
+            $this->notBlank($tab->name, 'Tab name attribute must not be empty');
         }
     }
 
@@ -67,7 +82,7 @@ final class Validator
                     Assertion::string($element->type, 'Element type attribute must be string');
                     Assertion::string($element->name, 'Element name attribute must be string');
                     Assertion::inArray($element->type, array('text', 'files', 'section', 'choice_radio', 'choice_checkbox'), 'Element must be of a supported type');
-                    Assertion::notBlank($element->name, 'Element name attribute must not be empty');
+                    $this->notBlank($element->name, 'Element name attribute must not be empty');
 
                     switch ($element->type) {
 
@@ -116,7 +131,7 @@ final class Validator
         Assertion::string($element->limit_type, 'Element limit_type attribute must be string');
         Assertion::integer($element->limit, 'Element limit attribute must be integer');
         Assertion::boolean($element->plain_text, 'Element plain_text attribute must be boolean');
-        Assertion::notBlank($element->label, 'Element label attribute must not be empty');
+        $this->notBlank($element->label, 'Element label attribute must not be empty');
         Assertion::inArray($element->limit_type, array('words', 'chars'), 'Element limit_type attribute value must be either "words" or "chars"');
         Assertion::min($element->limit, 0, 'Element limit attribute must not be negative');
     }
@@ -130,7 +145,7 @@ final class Validator
         Assertion::boolean($element->required, 'Element required attribute must be boolean');
         Assertion::string($element->label, 'Element label attribute must be string');
         Assertion::string($element->microcopy, 'Element microcopy attribute must be string');
-        Assertion::notBlank($element->label, 'Element label attribute must not be empty');
+        $this->notBlank($element->label, 'Element label attribute must not be empty');
     }
 
     private function validateSectionElement($element)
@@ -140,7 +155,7 @@ final class Validator
         Assertion::eq(count(get_object_vars($element)), 4, 'Element must not have additional attributes');
         Assertion::string($element->title, 'Element title attribute must be string');
         Assertion::string($element->subtitle, 'Element subtitle attribute must be string');
-        Assertion::notBlank($element->title, 'Element title attribute must not be empty');
+        $this->notBlank($element->title, 'Element title attribute must not be empty');
     }
 
     private function validateChoiceRadioElement($element)
@@ -156,8 +171,8 @@ final class Validator
         Assertion::string($element->microcopy, 'Element microcopy attribute must be string');
         Assertion::boolean($element->other_option, 'Element other_option attribute must be boolean');
         Assertion::isArray($element->options, 'Element options attribute must be array');
-        Assertion::notBlank($element->label, 'Element label attribute must not be empty');
-        Assertion::notEmpty($element->options, 'Element must have at least one option');
+        $this->notBlank($element->label, 'Element label attribute must not be empty');
+        $this->notBlank($element->options, 'Element must have at least one option');
 
         foreach ($element->options as $option) {
             $this->validateOptionFormatForChoiceRadio($option, $element);
@@ -213,8 +228,8 @@ final class Validator
         Assertion::string($element->label, 'Element label attribute must be string');
         Assertion::string($element->microcopy, 'Element microcopy attribute must be string');
         Assertion::isArray($element->options, 'Element options attribute must be array');
-        Assertion::notBlank($element->label, 'Element label attribute must not be empty');
-        Assertion::notEmpty($element->options, 'Element must have at least one option');
+        $this->notBlank($element->label, 'Element label attribute must not be empty');
+        $this->notBlank($element->options, 'Element must have at least one option');
 
         foreach ($element->options as $option) {
             $this->validateOptionFormatForChoiceCheckbox($option);
@@ -250,8 +265,8 @@ final class Validator
         Assertion::string($option->name, 'Option name attribute must be string');
         Assertion::string($option->label, 'Option label attribute must be string');
         Assertion::boolean($option->selected, 'Option selected attribute must be boolean');
-        Assertion::notBlank($option->name, 'Option name attribute must not be empty');
-        Assertion::notBlank($option->label, 'Option label attribute must not be empty');
+        $this->notBlank($option->name, 'Option name attribute must not be empty');
+        $this->notBlank($option->label, 'Option label attribute must not be empty');
 
         if ($element->other_option && json_encode($option) == json_encode(end($element->options))) {
 
@@ -274,8 +289,8 @@ final class Validator
         Assertion::string($option->name, 'Option name attribute must be string');
         Assertion::string($option->label, 'Option label attribute must be string');
         Assertion::boolean($option->selected, 'Option selected attribute must be boolean');
-        Assertion::notBlank($option->name, 'Option name attribute must not be empty');
-        Assertion::notBlank($option->label, 'Option label attribute must not be empty');
+        $this->notBlank($option->name, 'Option name attribute must not be empty');
+        $this->notBlank($option->label, 'Option label attribute must not be empty');
         Assertion::eq(count(get_object_vars($option)), 3, 'Option must not have additional attributes');
     }
 


### PR DESCRIPTION
New approach,  I created an internal method `notBlank` that replicates the old behaviour from the package.

This will ensure consistency for existing configs